### PR TITLE
fix(rules): allow scopes to be empty so long as scope overrides exist

### DIFF
--- a/config/testUnit/istanbul.yml
+++ b/config/testUnit/istanbul.yml
@@ -2,10 +2,10 @@ instrumentation:
   root: lib/
 check:
   global:
-    statements: 80
-    functions: 80
+    statements: 90
     branches: 80
-    lines: 80
+    functions: 80
+    lines: 90
   each:
     statements: 72
     functions: 50

--- a/lib/index.js
+++ b/lib/index.js
@@ -32,7 +32,7 @@ const PKG = require(path.join(APP_ROOT, '/package.json'));   // Find the root pa
 const MAX_LENGTH = 100;
 // Make commit scope optional.
 const PATTERN = /^(?:fixup!\s*)?(\w*)(\(([\w\$\.\-\*/]+)\))*\: (.*)$/;    //type(scope-min-3-chars): min-5-chars-starting-with-lowercase-letter
-const ISSUE_PATTERN = /(ibf-.*?)-/i;
+const ISSUE_PATTERN = /(ibf-.*?)-/i;    // Todo: make this configurable or remove it entirely
 const IGNORED = /^Merge branch|WIP\:|Release v/;
 const BREAKING_CHANGE_PATTERN = /BREAKING CHANGE:/;
 const MIN_SUBJECT_LENGTH = 3;
@@ -44,6 +44,7 @@ let SCOPES;
 let SCOPE_OVERRIDES;
 let allowCustomScopes;
 let allowBreakingChangesForType;
+let appendBranchNameToCommitMessage = true;    // Boolean
 
 // publish for testing
 module.exports = {
@@ -204,6 +205,8 @@ function processCLI(commitMsgFileName, cb) {
   let incorrectLogFileName = commitMsgFileName.replace('COMMIT_EDITMSG', 'logs/incorrect-commit-msgs');
   let callback = cb || function() {};   // Used for testing
 
+  appendBranchNameToCommitMessage = czConfig && czConfig.appendBranchNameToCommitMessage != undefined ? czConfig.appendBranchNameToCommitMessage : appendBranchNameToCommitMessage;
+
   fs.readFile(commitMsgFileName, function(err, buffer) {
     let lines = getLinesFromBuffer(buffer);
     let msg = lines.join('\n');
@@ -217,15 +220,21 @@ function processCLI(commitMsgFileName, cb) {
 
       console.info(chalk.bold.white.bgGreen('Commit message is valid.'));
 
-      // If valid, add the issue/branch name to the last line
-      exec('git rev-parse --abbrev-ref HEAD', function(err, stdout/*, stderr*/) {
-        let lastline = appendIssueToCommit(lines, getIssueFromBranch(stdout));
+      // Make it optional to append the branch name to the commit message
+      if (!appendBranchNameToCommitMessage) {
+        process.exit(0);
+        callback();
+      } else {
+        // If valid, add the issue/branch name to the last line
+        exec('git rev-parse --abbrev-ref HEAD', function(err, stdout/*, stderr*/) {
+          let lastline = appendIssueToCommit(lines, getIssueFromBranch(stdout));
 
-        fs.appendFile(commitMsgFileName, lastline, function() {
-          process.exit(0);
-          callback();
+          fs.appendFile(commitMsgFileName, lastline, function() {
+            process.exit(0);
+            callback();
+          });
         });
-      });
+      }
     }
   });
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -106,13 +106,16 @@ function validateMessage(firstLine, fullMsg) {
   let type = match[1];
   let scope = match[3];
   let subject = match[4];
+  let allowedScopesForType = SCOPE_OVERRIDES[type] ? SCOPE_OVERRIDES[type] : [];
+
+  allowedScopesForType = allowedScopesForType.map(item => item.name).concat(SCOPES);
 
   if (!TYPES.length) {
     commitError(`No valid types defined! Check your package.json and cz-customisable rules file and define the "types" there.`);
     return false;
   }
 
-  if (!SCOPES.length && !allowCustomScopes) {
+  if (!SCOPES.length && !allowCustomScopes && allowedScopesForType.indexOf(scope) === -1) {
     commitError(`No valid scopes defined! Check your package.json and cz-customisable rules file and define the "scopes" there (or set allowCustomScopes to true)`);
     return false;
   }
@@ -121,10 +124,6 @@ function validateMessage(firstLine, fullMsg) {
     commitError(`"${type}" is not allowed type!\nValid types: ${TYPES.join(', ')}`);
     return false;
   }
-
-  let allowedScopesForType = SCOPE_OVERRIDES[type] ? SCOPE_OVERRIDES[type] : [];
-
-  allowedScopesForType = allowedScopesForType.map(item => item.name).concat(SCOPES);
 
   if (!allowCustomScopes && allowedScopesForType.indexOf(scope) === -1) {
     commitError(`"${scope}" is not allowed scope for a "${type}" commit!\nValid "${type}" scopes: ${allowedScopesForType.sort().join(', ')}`);

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
       "config": "config/release/commitMessageConfig.js"
     },
     "ghooks": {
-      "commit-msg": "./node_modules/cz-customizable-ghooks/index.js $2",
+      "commit-msg": "./node_modules/cz-customizable-ghooks/lib/index.js $2",
       "pre-push": "npm-run-all verify test:unit:once --silent"
     }
   },
@@ -55,7 +55,7 @@
   "devDependencies": {
     "chokidar-cli": "1.2.0",
     "cz-customizable": "4.0.0",
-    "cz-customizable-ghooks": "1.1.2",
+    "cz-customizable-ghooks": "1.2.0",
     "eslint": "1.10.3",
     "eslint-config-defaults": "8.0.2",
     "ghooks": "1.2.1",

--- a/test/ccg.spec.js
+++ b/test/ccg.spec.js
@@ -87,7 +87,7 @@ describe('cz-customizable-ghooks', () => {
         types: [
           {value: 'feat', name: 'feat:     A new feature'},
           {value: 'fix', name: 'fix:      A bug fix'},
-          {value: 'docs', name: 'docs:     Documentation only changes'},
+          {value: 'docs', name: 'docs:     Documentation only changes'}
         ],
 
         scopes: [
@@ -117,7 +117,7 @@ describe('cz-customizable-ghooks', () => {
       };
 
       const testData = [
-        {msg: 'feat(customScope): this ok', expectedResult: false},
+        {msg: 'feat(customScope): this not ok', expectedResult: false},
         {msg: 'docs(custom): docs has an override scope', expectedResult: true},
         {msg: 'fix(merge): and so does fix', expectedResult: true},
         {msg: 'docs(invalidCustom): not a valid custom scope', expectedResult: false}
@@ -138,6 +138,66 @@ describe('cz-customizable-ghooks', () => {
         });
       });
     });
+
+
+    describe('with no scopes but with scope overridesForTypes', () => {
+      let baseScopes = [
+        {name: 'merge'},
+        {name: 'style'},
+        {name: 'e2eTest'},
+        {name: 'unitTest'}
+      ];
+      let config = {
+        types: [
+          {value: 'feat', name: 'feat:     A new feature'},
+          {value: 'fix', name: 'fix:      A bug fix'},
+          {value: 'docs', name: 'docs:     Documentation only changes'}
+        ],
+
+        scopeOverrides: {
+          fix: baseScopes,
+          docs: baseScopes.concat({name: 'custom'})
+        },
+        allowCustomScopes: false,
+        allowBreakingChanges: ['feat', 'fix'],
+        process: {
+          exit: () => {}
+        }
+      };
+
+      const testData = [
+        {msg: 'fix(merge): this ok', expectedResult: true},
+        {msg: 'docs(custom): this has an override scope', expectedResult: true},
+        {msg: 'feat(merge): no scopes for feature', expectedResult: false},
+        {msg: 'docs(invalidCustom): not a valid custom scope', expectedResult: false}
+      ];
+
+      let consoleData = '';
+
+      beforeEach(() => {
+        module = rewire('../lib/index');
+        module.__set__({
+          czConfig: config,
+          console: {
+            log: (data) => consoleData += data,
+            error: (data) => consoleData += data
+          }
+        });
+      });
+
+      afterEach(() => {
+        consoleData = '';
+      });
+
+      it('should accept commit messages which match the rules in the config', () => {
+        testData.forEach(test => {
+          let lines = test.msg.split('\n');
+
+          assert.equal(module.validateMessage(lines[0], test.msg), test.expectedResult, test.msg);// + '\n' + consoleData);
+        });
+      });
+    });
+
 
     describe('error conditions', () => {
       let consoleData = '';
@@ -213,7 +273,7 @@ describe('cz-customizable-ghooks', () => {
         });
       });
 
-      it('should accept commit messages which match the rules in the config', () => {
+      it('should reject commit messages which do not match the rules in the config', () => {
         testData.forEach(test => {
           module.__set__({czConfig: test.config});
 


### PR DESCRIPTION
fix/base-scopes-optional-if-override-scopes-exist