### PR TITLE
fix: use value field for scopes and process undefined scope

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -81,7 +81,7 @@ function commitError() {
 function validateMessage(firstLine, fullMsg) {
   // Allowed scope and types. These are mandatory, but guard against it anyway
   TYPES = (czConfig.types || []).map(item => item.value);
-  SCOPES = (czConfig.scopes || []).map(item => item.name);
+  SCOPES = (czConfig.scopes || []).map(item => item.value || item.name);
   SCOPE_OVERRIDES = czConfig.scopeOverrides || {};
 
   allowCustomScopes = czConfig.allowCustomScopes !== undefined ? !!czConfig.allowCustomScopes : false;  // Convert to boolean. If undefined, do not allow custom scopes.
@@ -109,7 +109,7 @@ function validateMessage(firstLine, fullMsg) {
   let subject = match[4];
   let allowedScopesForType = SCOPE_OVERRIDES[type] ? SCOPE_OVERRIDES[type] : [];
 
-  allowedScopesForType = allowedScopesForType.map(item => item.name).concat(SCOPES);
+  allowedScopesForType = allowedScopesForType.map(item => item.value || item.name).concat(SCOPES);
 
   if (!TYPES.length) {
     commitError(`No valid types defined! Check your package.json and cz-customisable rules file and define the "types" there.`);
@@ -126,7 +126,7 @@ function validateMessage(firstLine, fullMsg) {
     return false;
   }
 
-  if (!allowCustomScopes && allowedScopesForType.indexOf(scope) === -1) {
+  if (!allowCustomScopes && allowedScopesForType.indexOf(scope || '') === -1) {
     commitError(`"${scope}" is not allowed scope for a "${type}" commit!\nValid "${type}" scopes: ${allowedScopesForType.sort().join(', ')}`);
     return false;
   }


### PR DESCRIPTION
fixes case for config using values and allows empty value without allowing custom scopes.
example config:

``` js
{
  scopes: [
    {name: 'SomeScope'},
    {name: '-- empty --', value: ''}
  ],
  allowCustomScopes: false
}
```
