### PR TITLE
Fix appending of branchName multiple times when doing git commit --amend

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -186,7 +186,7 @@ function appendIssueToCommit(lines, issue) {
   let i = lines.length - 1;
 
   // Try to find a non-blank line to see if the last line already contains the issue
-  while (lastLine === '' && i >= 0) {
+  while ((lastLine === '' || /^#/.test(lastLine)) && i >= 0) {
     lastLine = lines[i--];
   }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -32,7 +32,6 @@ const PKG = require(path.join(APP_ROOT, '/package.json'));   // Find the root pa
 const MAX_LENGTH = 100;
 // Make commit scope optional.
 const PATTERN = /^(?:fixup!\s*)?(\w*)(\(([\w\$\.\-\*/]+)\))*\: (.*)$/;    // type(scope-min-3-chars): min-5-chars-starting-with-lowercase-letter
-const ISSUE_PATTERN = /(ibf-.*?)-/i;    // Todo: make this configurable or remove it entirely
 const IGNORED = /^Merge branch|WIP\:|Release v/;
 const BREAKING_CHANGE_PATTERN = /BREAKING CHANGE:/;
 const MIN_SUBJECT_LENGTH = 3;
@@ -170,29 +169,19 @@ function getLinesFromBuffer(buffer) {
 }
 
 
-function getIssueFromBranch(branchName) {
-  let issue = branchName;
-  let result = branchName.match(ISSUE_PATTERN);
-
-  if (result && result[1]) {
-    issue = (result[1] || '').toUpperCase();
-  }
-  return issue;
-}
-
-function appendIssueToCommit(lines, issue) {
+function appendBranchNameToCommit(lines, branchName) {
   let result = '';
   let lastLine = '';
   let i = lines.length - 1;
 
-  // Try to find a non-blank line to see if the last line already contains the issue
+  // Try to find a non-blank line to see if the last line already contains the branchName
   while ((lastLine === '' || /^#/.test(lastLine)) && i >= 0) {
     lastLine = lines[i--];
   }
 
-  // If the last line does NOT contain the issue already, add it
-  if (lastLine.toUpperCase().indexOf(issue) === -1) {
-    result = '\n\n' + issue;
+  // If the last line does NOT contain the branchName already, add it
+  if (lastLine !== branchName) {
+    result = '\n\n' + branchName;
   }
   return result;
 }
@@ -227,9 +216,9 @@ function processCLI(commitMsgFileName, cb) {
         process.exit(0); // eslint-disable-line
         callback();
       } else {
-        // If valid, add the issue/branch name to the last line
+        // If valid, add the branch name to the last line
         exec('git rev-parse --abbrev-ref HEAD', (err, stdout/* , stderr*/) => {
-          let lastline = appendIssueToCommit(lines, getIssueFromBranch(stdout));
+          let lastline = appendBranchNameToCommit(lines, stdout.trim());
 
           fs.appendFile(commitMsgFileName, lastline, () => {
             process.exit(0);  // eslint-disable-line


### PR DESCRIPTION
This PR fixes multiple branchName appending when doing git commit --amend by ignoring blank lines as well as comment lines.

It also removes the issue matching mechanism for it to work. There was a // todo that said:

```
const ISSUE_PATTERN = /(ibf-.*?)-/i;    // Todo: make this configurable or remove it entirely
```

I decided to remove it entirely because we want to add the branchName, not the issue, like the `appendBranchNameToCommitMessage` option says. Moreover, it was bringing complexity to the code. I think now with this patch, it is doing one simple thing and does it well.

Best,