### PR TITLE
Fix husky GIT_PARAMS

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -246,7 +246,7 @@ if (process.argv.join('').indexOf('mocha') === -1) {
   if (!readConfigFile()) {
     process.exit(1);  // eslint-disable-line
   }
-  processCLI(process.argv[2] || process.env.GIT_PARAMS);  // GIT_PARAMS are made available when using husky
+  processCLI(process.argv[2] || process.env.GIT_PARAMS || process.env.HUSKY_GIT_PARAMS);  // GIT_PARAMS are made available when using husky
 } else {
   console.log('Running in mocha');
 }


### PR DESCRIPTION
Husky has changed the name of `GIT_PARAMS` to `HUSKY_GIT_PARAMS`, which breaks this package with the latest versions of husky.

https://github.com/typicode/husky/blob/6fd89e8fccf6ca7590743cd8b4ce9643de7091e5/DOCS.md#access-git-params-and-stdin