### PR TITLE
fix(design): Git params to support husky v4.*.*

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -246,7 +246,7 @@ if (process.argv.join('').indexOf('mocha') === -1) {
   if (!readConfigFile()) {
     process.exit(1);  // eslint-disable-line
   }
-  processCLI(process.argv[2] || process.env.GIT_PARAMS);  // GIT_PARAMS are made available when using husky
+  processCLI(process.argv[2] || process.env.HUSKY_GIT_PARAMS || process.env.GIT_PARAMS);  // GIT_PARAMS are made available when using husky
 } else {
   console.log('Running in mocha');
 }


### PR DESCRIPTION
Husky upgrade to 4.*.* has renamed `GIT_PARAMS` to `HUSKY_GIT_PARAMS`.
To have package backward compatible support both params.
husky upgrade(https://github.com/typicode/husky#upgrading-from-014)