### PR TITLE
Fix husky hooks tutorial in README.md 

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ npm i husky
 ```
   "husky": {
     "hooks": {
-      "commitmsg": "cz-customizable-ghooks"
+      "commit-msg": "cz-customizable-ghooks"
     }
   }
 ```


### PR DESCRIPTION
in husky config `commit-msg` works but `commitmsg` doesnt. Hence updating the README to reflect the same.
Tested on macos with node10 and latest version of husky, cz-customizable and cz-customizable-ghooks